### PR TITLE
Method names

### DIFF
--- a/docs/usage/intro.md
+++ b/docs/usage/intro.md
@@ -49,3 +49,29 @@ and [**`expand`**](expand.md) endpoints.
 
 !!!info
     There is also a mirror [asynchronous client](async.md) providing the same interface in the `dripostal.aio` module.
+
+### API Method Names
+In case your Libpostal REST service has a different API layout,
+DriPostal allows you to modify the names of the target API methods, for both `parse` and `expand`.
+To do so, you should specify them when initializing the class:
+```python
+from dripostal import DriPostal
+
+dripostal = DriPostal(
+    url="http://0.0.0.0:4400", 
+    parse_method="parser", 
+    expand_method="expander",
+)
+```
+In the example above, DriPostal's `parse` method will be querying `http://0.0.0.0:4400/parser` 
+instead of `http://0.0.0.0:4400/parse`, and its `expand` method will be querying 
+`http://0.0.0.0:4400/expander`. 
+
+!!!warning
+    DriPostal is designed to interact with GET-based Libpostal REST APIs. Its URL template is:
+    ```
+    <schema>://<domain>/<method>?q=<query>
+    ```
+
+    If you are trying to query a POST-based Libpostal REST service like 
+    [`libpostal-rest-docker`](https://github.com/johnlonganecker/libpostal-rest-docker) DriPostal is not your tool 😔

--- a/dripostal/__init__.py
+++ b/dripostal/__init__.py
@@ -24,14 +24,20 @@ __version__ = version(__name__)
 class DriPostal:
     """Wrapper for binding pelias/libpostal service."""
 
-    def __init__(self, url: str):
+    def __init__(
+        self, url: str, parse_method: str = "parse", expand_method: str = "expand"
+    ):
         """Dripostal configuration.
 
         Args:
             url: URL of the Libpostal service.
+            parse_method: Parse method name in the API.
+            expand_method: Expand method name in the API.
 
         """
         self.service_url: AnyHttpUrl = self._parse_url(url)
+        self._parse_method: str = parse_method
+        self._expand_method: str = expand_method
 
     @staticmethod
     def _parse_url(url: str):
@@ -67,7 +73,7 @@ class DriPostal:
         Returns: Parsed address.
 
         """
-        request_url = self._get_url(method="parse", address=address)
+        request_url = self._get_url(method=self._parse_method, address=address)
         response = request.urlopen(request_url)
         payload = json.loads(response.read())
         return Address(**{el["label"]: el["value"] for el in payload})
@@ -81,7 +87,7 @@ class DriPostal:
         Returns: Expanded address.
 
         """
-        request_url = self._get_url(method="expand", address=address)
+        request_url = self._get_url(method=self._expand_method, address=address)
         response = request.urlopen(request_url)
         payload = json.loads(response.read())
         return payload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,3 @@ def event_loop():
     """Provide an event loop to aio tests."""
     loop = asyncio.get_event_loop()
     yield loop
-
-
-def pytest_sessionfinish(*_):
-    """Close the event loop on the test session's end."""
-    asyncio.get_event_loop().close()

--- a/tests/test_dripostal.py
+++ b/tests/test_dripostal.py
@@ -67,7 +67,6 @@ def test_parse(mocker: MockerFixture, scheme, host):
         host: Parametrized host.
 
     """
-    host = utils.random_lower_string()
     url = f"{scheme}://{host}"
     fake_parse_response = [
         {"label": label, "value": utils.random_lower_string()}
@@ -89,7 +88,7 @@ def test_parse(mocker: MockerFixture, scheme, host):
     arg_1, *args = magic_mocker.call_args[0]
     assert isinstance(arg_1, AnyHttpUrl)
     assert arg_1.scheme == scheme
-    assert arg_1.host == host
+    assert arg_1.host == host.rstrip("/")
     assert arg_1.path == "/parse"
     assert parse.parse_qs(arg_1.query) == {"address": [input_address]}
 
@@ -111,7 +110,6 @@ def test_expand(mocker: MockerFixture, host, scheme):
         host: Parametrized host.
 
     """
-    host = utils.random_lower_string()
     url = f"{scheme}://{host}"
     fake_expand_response = [utils.random_lower_string()]
     magic_mocker = mocker.patch(
@@ -129,6 +127,6 @@ def test_expand(mocker: MockerFixture, host, scheme):
     arg_1, *args = magic_mocker.call_args[0]
     assert isinstance(arg_1, AnyHttpUrl)
     assert arg_1.scheme == scheme
-    assert arg_1.host == host
+    assert arg_1.host == host.rstrip("/")
     assert arg_1.path == "/expand"
     assert parse.parse_qs(arg_1.query) == {"address": [input_address]}


### PR DESCRIPTION
Added the option of specifying different names for the Libpostal REST API `parse` and `expand` methods.